### PR TITLE
Update Athena JDBC driver avaible on bucket

### DIFF
--- a/aws-blog-vpcflowlogs-athena-quicksight/PartitioningFunction/readme.md
+++ b/aws-blog-vpcflowlogs-athena-quicksight/PartitioningFunction/readme.md
@@ -10,8 +10,8 @@ As a one-off operation, you'll need to install the Athena JDBC driver into a lib
 
 ```
 mkdir lib
-aws s3 cp s3://athena-downloads/drivers/AthenaJDBC41-1.0.0.jar lib/
-mvn install:install-file -Dfile=lib/AthenaJDBC41-1.0.0.jar -DgroupId=com.amazonaws -DartifactId=athena.jdbc41 -Dversion=1.0.0 -Dpackaging=jar -DgeneratePom=true
+aws s3 cp s3://athena-downloads/drivers/AthenaJDBC41-1.1.0.jar lib/
+mvn install:install-file -Dfile=lib/AthenaJDBC41-1.1.0.jar -DgroupId=com.amazonaws -DartifactId=athena.jdbc41 -Dversion=1.1.0 -Dpackaging=jar -DgeneratePom=true
 ```
 
 And then, to build:


### PR DESCRIPTION
The file version of the Athena JDBC driver seems to have been updated in the bucket and thus the previous commands to copy and install it were not working.
This patch updates the instructions.